### PR TITLE
feat: 키워드·소스 구독 기반 푸시 알림 파이프라인 구현

### DIFF
--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Delete, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { NotificationsService } from './services/notifications.service';
 import { JwtGuard } from '@src/auth/guards/jwt.guard';
 import { CurrentUser } from '@src/auth/decorators/current-user.decorator';
@@ -14,6 +22,26 @@ export class NotificationsController {
     @Body('expoPushToken') expoPushToken: string,
   ) {
     await this.notificationsService.saveExpoToken(userId, expoPushToken);
+  }
+
+  @Patch('expo-token')
+  @UseGuards(JwtGuard)
+  async setExpoTokenActive(
+    @CurrentUser('id') userId: string,
+    @Body('expoPushToken') expoPushToken: string,
+    @Body('isActive') isActive: boolean,
+  ) {
+    await this.notificationsService.setExpoTokenActive(
+      userId,
+      expoPushToken,
+      isActive,
+    );
+  }
+
+  @Get('keywords')
+  @UseGuards(JwtGuard)
+  async getKeywords(@CurrentUser('id') userId: string) {
+    return this.notificationsService.getKeywords(userId);
   }
 
   @Post('keywords')
@@ -32,6 +60,12 @@ export class NotificationsController {
     @Body('keywords') keywords: string[],
   ) {
     return await this.notificationsService.deleteKeywords(userId, keywords);
+  }
+
+  @Get('sources')
+  @UseGuards(JwtGuard)
+  async getSources(@CurrentUser('id') userId: string) {
+    return this.notificationsService.getSources(userId);
   }
 
   @Post('sources')

--- a/src/notifications/notifications.controller.ts
+++ b/src/notifications/notifications.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Delete,
   Get,
+  ParseBoolPipe,
   Patch,
   Post,
   UseGuards,
@@ -29,7 +30,7 @@ export class NotificationsController {
   async setExpoTokenActive(
     @CurrentUser('id') userId: string,
     @Body('expoPushToken') expoPushToken: string,
-    @Body('isActive') isActive: boolean,
+    @Body('isActive', ParseBoolPipe) isActive: boolean,
   ) {
     await this.notificationsService.setExpoTokenActive(
       userId,

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -27,12 +27,25 @@ export class NotificationsRepository extends Repository<ExpoToken> {
     if (userIds.length === 0) return [];
     return this.find({ where: { userId: In(userIds), isActive: true } });
   }
+
+  async setActive(
+    userId: string,
+    expoPushToken: string,
+    isActive: boolean,
+  ): Promise<void> {
+    await this.update({ userId, expoPushToken }, { isActive });
+  }
 }
 
 @Injectable()
 export class KeywordSubscriptionsRepository extends Repository<KeywordSubscription> {
   constructor(dataSource: DataSource) {
     super(KeywordSubscription, dataSource.manager);
+  }
+
+  async findByUserId(userId: string): Promise<string[]> {
+    const rows = await this.find({ where: { userId }, select: ['keyword'] });
+    return rows.map((r) => r.keyword);
   }
 
   async saveMany(userId: string, keywords: string[]): Promise<number> {
@@ -43,8 +56,11 @@ export class KeywordSubscriptionsRepository extends Repository<KeywordSubscripti
       .values(keywords.map((keyword) => ({ userId, keyword })))
       .orIgnore()
       .execute();
-    const affectedRows = (result.raw as { affectedRows?: number })?.affectedRows;
-    return typeof affectedRows === 'number' ? affectedRows : result.identifiers.length;
+    const affectedRows = (result.raw as { affectedRows?: number })
+      ?.affectedRows;
+    return typeof affectedRows === 'number'
+      ? affectedRows
+      : result.identifiers.length;
   }
 
   async deleteMany(userId: string, keywords: string[]): Promise<number> {
@@ -97,6 +113,11 @@ export class SourceSubscriptionsRepository extends Repository<SourceSubscription
     super(SourceSubscription, dataSource.manager);
   }
 
+  async findByUserId(userId: string): Promise<string[]> {
+    const rows = await this.find({ where: { userId }, select: ['source'] });
+    return rows.map((r) => r.source);
+  }
+
   async saveMany(userId: string, sources: string[]): Promise<number> {
     if (sources.length === 0) return 0;
     const result = await this.createQueryBuilder()
@@ -105,8 +126,11 @@ export class SourceSubscriptionsRepository extends Repository<SourceSubscription
       .values(sources.map((source) => ({ userId, source })))
       .orIgnore()
       .execute();
-    const affectedRows = (result.raw as { affectedRows?: number })?.affectedRows;
-    return typeof affectedRows === 'number' ? affectedRows : result.identifiers.length;
+    const affectedRows = (result.raw as { affectedRows?: number })
+      ?.affectedRows;
+    return typeof affectedRows === 'number'
+      ? affectedRows
+      : result.identifiers.length;
   }
 
   async deleteMany(userId: string, sources: string[]): Promise<number> {

--- a/src/notifications/services/notifications.service.ts
+++ b/src/notifications/services/notifications.service.ts
@@ -44,6 +44,26 @@ export class NotificationsService {
     return this.notificationsRepository.saveExpoToken(userId, expoPushToken);
   }
 
+  async getKeywords(userId: string): Promise<string[]> {
+    return this.keywordSubscriptionsRepository.findByUserId(userId);
+  }
+
+  async getSources(userId: string): Promise<string[]> {
+    return this.sourceSubscriptionsRepository.findByUserId(userId);
+  }
+
+  async setExpoTokenActive(
+    userId: string,
+    expoPushToken: string,
+    isActive: boolean,
+  ): Promise<void> {
+    return this.notificationsRepository.setActive(
+      userId,
+      expoPushToken,
+      isActive,
+    );
+  }
+
   async saveKeywords(
     userId: string,
     keywords: string[],

--- a/src/notifications/services/notifications.service.ts
+++ b/src/notifications/services/notifications.service.ts
@@ -57,6 +57,9 @@ export class NotificationsService {
     expoPushToken: string,
     isActive: boolean,
   ): Promise<void> {
+    if (!Expo.isExpoPushToken(expoPushToken)) {
+      throw new BadRequestException('Invalid Expo push token');
+    }
     return this.notificationsRepository.setActive(
       userId,
       expoPushToken,


### PR DESCRIPTION
## Summary

- 키워드/소스 구독 기반 Expo 푸시 알림 파이프라인 구현
- Aho-Corasick 다중 패턴 매칭으로 공지 제목 키워드 탐색
- 참조 카운트 기반 아호코라식 관리 (다른 유저 구독 중인 키워드는 삭제 안 함)
- 멀티 디바이스 지원 (유저당 복수 Expo 토큰)
- Scatter-Gather 스크래핑 오케스트레이터 (동시성 3개 제한)
- 키워드/소스 조회 및 알림 활성화 토글 엔드포인트 추가
- PR merge 시 변경된 컨트롤러를 OpenAI로 분석해 Notion에 API 명세 자동 작성
- 마이그레이션을 앱 기동 전에 실행하도록 배포 순서 수정

## Test Plan

- [ ] `POST /notifications/expo-token` — 토큰 저장, 유효하지 않은 토큰 400 확인
- [ ] `PATCH /notifications/expo-token` — isActive 토글 확인
- [ ] `GET /notifications/keywords` / `GET /notifications/sources` — 목록 조회 확인
- [ ] `POST /notifications/keywords` — `{ added, ignored }` 응답 확인
- [ ] `DELETE /notifications/keywords` — `{ deleted }` 응답 + 참조 카운트 감소 확인
- [ ] 스크래핑 크론 실행 후 키워드·소스 매칭 알림 수신 확인
- [ ] 멀티 디바이스: 동일 userId로 토큰 2개 등록 후 알림 2건 수신 확인
- [ ] PR merge → GitHub Actions → Notion 페이지 생성 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)