### PR TITLE
fix: 알림 파이프라인 버그 수정

### DIFF
--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -3,6 +3,9 @@ import { ExpoToken } from './entities/expo-token.entity';
 import { Repository, DataSource, In } from 'typeorm';
 import { KeywordSubscription } from './entities/keyword-subscriptions.entity';
 import { SourceSubscription } from './entities/source-subscription.entity';
+import { UUIDTransformer } from '@src/common/transformers/uuid.transformer';
+
+const uuidTransformer = new UUIDTransformer();
 
 @Injectable()
 export class NotificationsRepository extends Repository<ExpoToken> {
@@ -95,12 +98,12 @@ export class KeywordSubscriptionsRepository extends Repository<KeywordSubscripti
       .select('ks.keyword', 'keyword')
       .addSelect('ks.user_id', 'userId')
       .where('ks.keyword IN (:...keywords)', { keywords })
-      .getRawMany<{ keyword: string; userId: string }>();
+      .getRawMany<{ keyword: string; userId: Buffer }>();
 
     const result = new Map<string, string[]>();
     for (const { keyword, userId } of rows) {
       const list = result.get(keyword) ?? [];
-      list.push(userId);
+      list.push(uuidTransformer.from(userId) as string);
       result.set(keyword, list);
     }
     return result;
@@ -154,12 +157,12 @@ export class SourceSubscriptionsRepository extends Repository<SourceSubscription
       .select('ss.source', 'source')
       .addSelect('ss.user_id', 'userId')
       .where('ss.source IN (:...sources)', { sources })
-      .getRawMany<{ source: string; userId: string }>();
+      .getRawMany<{ source: string; userId: Buffer }>();
 
     const result = new Map<string, string[]>();
     for (const { source, userId } of rows) {
       const list = result.get(source) ?? [];
-      list.push(userId);
+      list.push(uuidTransformer.from(userId) as string);
       result.set(source, list);
     }
     return result;

--- a/src/notifications/notifications.repository.ts
+++ b/src/notifications/notifications.repository.ts
@@ -51,6 +51,15 @@ export class KeywordSubscriptionsRepository extends Repository<KeywordSubscripti
     return rows.map((r) => r.keyword);
   }
 
+  async findExistingKeywords(userId: string, keywords: string[]): Promise<Set<string>> {
+    if (keywords.length === 0) return new Set();
+    const rows = await this.find({
+      where: { userId, keyword: In(keywords) },
+      select: ['keyword'],
+    });
+    return new Set(rows.map((r) => r.keyword));
+  }
+
   async saveMany(userId: string, keywords: string[]): Promise<number> {
     if (keywords.length === 0) return 0;
     const result = await this.createQueryBuilder()

--- a/src/notifications/services/notifications.service.ts
+++ b/src/notifications/services/notifications.service.ts
@@ -71,9 +71,17 @@ export class NotificationsService {
     userId: string,
     keywords: string[],
   ): Promise<{ added: number; ignored: number }> {
-    const existing = await this.keywordSubscriptionsRepository.findExistingKeywords(userId, keywords);
-    const newToUser = keywords.filter((k) => !existing.has(k));
-    const added = await this.keywordSubscriptionsRepository.saveMany(userId, keywords);
+    const unique = Array.from(new Set(keywords));
+    const existing =
+      await this.keywordSubscriptionsRepository.findExistingKeywords(
+        userId,
+        unique,
+      );
+    const newToUser = unique.filter((k) => !existing.has(k));
+    const added = await this.keywordSubscriptionsRepository.saveMany(
+      userId,
+      unique,
+    );
     if (newToUser.length > 0) {
       this.keywordSearchService
         .addKeywords(newToUser)
@@ -86,9 +94,17 @@ export class NotificationsService {
     userId: string,
     keywords: string[],
   ): Promise<{ deleted: number }> {
-    const existing = await this.keywordSubscriptionsRepository.findExistingKeywords(userId, keywords);
-    const toDelete = keywords.filter((k) => existing.has(k));
-    const deleted = await this.keywordSubscriptionsRepository.deleteMany(userId, keywords);
+    const unique = Array.from(new Set(keywords));
+    const existing =
+      await this.keywordSubscriptionsRepository.findExistingKeywords(
+        userId,
+        unique,
+      );
+    const toDelete = unique.filter((k) => existing.has(k));
+    const deleted = await this.keywordSubscriptionsRepository.deleteMany(
+      userId,
+      unique,
+    );
     if (toDelete.length > 0) {
       this.keywordSearchService
         .deleteKeywords(toDelete)

--- a/src/notifications/services/notifications.service.ts
+++ b/src/notifications/services/notifications.service.ts
@@ -71,13 +71,14 @@ export class NotificationsService {
     userId: string,
     keywords: string[],
   ): Promise<{ added: number; ignored: number }> {
-    const added = await this.keywordSubscriptionsRepository.saveMany(
-      userId,
-      keywords,
-    );
-    this.keywordSearchService
-      .addKeywords(keywords)
-      .catch((error) => this.logger.error('Error adding keywords:', error));
+    const existing = await this.keywordSubscriptionsRepository.findExistingKeywords(userId, keywords);
+    const newToUser = keywords.filter((k) => !existing.has(k));
+    const added = await this.keywordSubscriptionsRepository.saveMany(userId, keywords);
+    if (newToUser.length > 0) {
+      this.keywordSearchService
+        .addKeywords(newToUser)
+        .catch((error) => this.logger.error('Error adding keywords:', error));
+    }
     return { added, ignored: keywords.length - added };
   }
 
@@ -85,13 +86,14 @@ export class NotificationsService {
     userId: string,
     keywords: string[],
   ): Promise<{ deleted: number }> {
-    const deleted = await this.keywordSubscriptionsRepository.deleteMany(
-      userId,
-      keywords,
-    );
-    this.keywordSearchService
-      .deleteKeywords(keywords)
-      .catch((error) => this.logger.error('Error deleting keywords:', error));
+    const existing = await this.keywordSubscriptionsRepository.findExistingKeywords(userId, keywords);
+    const toDelete = keywords.filter((k) => existing.has(k));
+    const deleted = await this.keywordSubscriptionsRepository.deleteMany(userId, keywords);
+    if (toDelete.length > 0) {
+      this.keywordSearchService
+        .deleteKeywords(toDelete)
+        .catch((error) => this.logger.error('Error deleting keywords:', error));
+    }
     return { deleted };
   }
 


### PR DESCRIPTION
## Summary

- `getRawMany` 결과의 `user_id` Buffer를 UUID 문자열로 변환하지 않아 푸시 알림이 실패하던 버그 수정
- 키워드 refcount 불일치 버그 수정 — 중복 구독/미구독 키워드에도 refcount가 잘못 변경되어 Aho-Corasick 자동자가 틀어지던 문제 해결

## Test Plan

- [ ] 키워드 구독 후 스크래핑 크론 실행 시 푸시 알림 정상 수신 확인
- [ ] 동일 키워드 중복 구독 시도 시 refcount 변화 없음 확인
- [ ] 없는 키워드 삭제 시도 시 refcount 변화 없음 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)