### PR TITLE
chore: 팀 공용 계정 및 로컬 개발환경 셋업 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,12 +33,3 @@ JWT_REFRESH_EXPIRATION=
 
 # slack webhook
 FEEDBACK_WEB_HOOK_URL=
-
-# OpenAI API 키 (https://platform.openai.com/api-keys)
-OPENAI_API_KEY=
-
-# Notion Integration 토큰 (https://www.notion.so/my-integrations)
-NOTION_API_TOKEN=
-
-# Notion DB ID (DB 페이지 URL에서 추출: notion.so/workspace/{DATABASE_ID}?v=...)
-NOTION_DATABASE_ID=

--- a/README.md
+++ b/README.md
@@ -5,56 +5,80 @@
 ## 📌 주요 기술 스택 (Tech Stack)
 
 - **Framework**: [NestJS](https://nestjs.com/) (TypeScript)
-- **Database**: MySQL
-- **ORM**: [TypeORM](https://typeorm.io/)
-- **Authentication**: JWT, Passport, OAuth (Apple Login 예정)
-- **Task Scheduling**: @nestjs/schedule (공지사항 정기 크롤링)
-- **Push Notifications**: Expo Server SDK (예정)
+- **Database**: MySQL 8.0 (Docker)
+- **ORM**: [TypeORM](https://typeorm.io/) (`synchronize: false`, 마이그레이션 기반 스키마 관리)
+- **Cache/Queue**: Redis (랭킹 캐시, 유저 프로필 캐시, 점수 로그 버퍼링)
+- **Authentication**: JWT (access/refresh), Passport, OAuth (Apple, Google)
+- **Task Scheduling**: `@nestjs/schedule` (공지사항 정기 크롤링, cron)
+- **Push Notifications**: Expo Server SDK
+- **배포**: Docker + docker-compose, GitHub Actions CD → DigitalOcean
 
 ## 🏗️ 도메인 및 모듈 구조 (Structure)
 
 해당 애플리케이션은 기능별로 응집도가 높은 모듈(Module) 단위로 나뉘어 설계되었습니다.
 
-- `AuthModule`: JWT 토큰 발급/검증 및 인증 인가 가드(Guards), 소셜 로그인 기능
+- `AuthModule`: JWT 토큰 발급/검증 및 인증 인가 가드(Guards), Apple/Google 소셜 로그인
 - `UsersModule`: 사용자 기본 정보(OAuth 연동) 및 프로필(단과대, 학과 정보) 분리 관리
-- `NoticesModule`: 학교 공지사항 등 유용한 데이터 제공 기능
-- `ScraperModule`: 주기적인 외부 데이터 크롤링 및 수집
-- `InteractionsModule`: (예정) 좋아요, 피드백 등 사용자 상호작용 관련 로직
-- `NotificationsModule`: (예정) Expo를 활용한 푸시 알림 발송
+- `NoticesModule`: 학교 공지사항 조회 및 커서 기반 페이지네이션 제공
+- `ScraperModule`: 주기적인 외부 공지사항 크롤링 및 수집, 마감일 추출
+- `GamesModule`: 게임 점수 제출 및 랭킹(전체/단과대/학과) 조회
+- `FeedbacksModule`: 사용자 피드백 수집 (Slack webhook 연동)
+- `NotificationsModule`: 키워드/소스 구독 기반 Expo 푸시 알림 발송
 
-## ⚙️ 로컬 환경 스크립트 (Scripts)
+## ⚙️ 로컬 개발 환경 (Local Setup)
 
-### 의존성 설치 (Installation)
+### 사전 준비물
+
+- Docker, Docker Compose
+- Node.js ≥24 (Docker 없이 직접 실행할 경우에만 필요)
+
+### 1. 환경 변수 설정
+
+```bash
+$ cp .env.example .env
+```
+
+`.env` 파일을 열어 값을 채워 넣습니다. 발급처는 [🔑 필수 자격증명 및 계정](#-필수-자격증명-및-계정) 참고.
+
+### 2. 컨테이너 실행 (원클릭)
+
+```bash
+$ docker-compose up -d
+```
+
+`api` 컨테이너 기동 시 **마이그레이션이 자동으로 실행**된 뒤 dev 서버가 뜹니다 (`npm run migration:run && npm run start:dev`). DB/Redis 컨테이너까지 함께 올라오므로 별도 설치 없이 바로 개발 가능합니다.
+
+### 3. 확인
+
+```bash
+$ curl http://localhost:3000
+```
+
+### Docker 없이 직접 실행하는 경우
 
 ```bash
 $ npm install
-```
-
-### 서버 실행 (Running the app)
-
-```bash
-# 개발 모드 (Watch mode)
+$ npm run migration:run   # DB가 로컬에 별도로 떠 있어야 함
 $ npm run start:dev
-
-# 디버그 모드
-$ npm run start:debug
-
-# 프로덕션 빌드 실행
-$ npm run start:prod
 ```
 
-### 환경 변수 관리 (Environment variables)
-
-루트 하위의 `.env.example` 파일을 참고하여 `.env` 혹은 `.env.local` 파일을 생성한 뒤, 로컬 Database 환경 및 시크릿 키 등을 입력해 주어야 합니다.
-
-## 🐳 Docker 지원 (Docker Support)
-
-본 프로젝트는 원활한 운영 및 배포를 위해 Docker 환경을 지원합니다.
+## 🐳 프로덕션 배포 (Docker Support)
 
 ```bash
-# 로컬 개발용 컨테이너 실행
-$ docker-compose up -d
-
-# 상용 운영 컨테이너 실행
 $ docker-compose -f docker-compose.prod.yml up -d
 ```
+
+`main` 브랜치에 push되면 GitHub Actions(`.github/workflows/deploy.yml`)가 DigitalOcean 서버에 SSH로 접속해 `git pull` → 빌드 → 마이그레이션 → 재기동을 자동 수행합니다.
+
+## 🔑 필수 자격증명 및 계정
+
+로컬 개발 및 배포를 위해 아래 계정/자격증명에 대한 접근 권한이 필요합니다. 팀 공용 계정 설정 절차는 [TEAM_SETUP.md](./TEAM_SETUP.md)를 참고하세요.
+
+| 항목 | 용도 | 비고 |
+| --- | --- | --- |
+| Apple Developer 계정 | Apple 로그인 (Sign in with Apple), App Store 배포 | `.p8` 서명 키 필요 |
+| Google Cloud Console 프로젝트 | Google 로그인 (OAuth Client) | Web Client ID/Secret |
+| DigitalOcean 계정 | 프로덕션 서버 호스팅 | SSH 키 필요 |
+| GitHub 리포지토리 시크릿 | CD 파이프라인 (`HOST`, `USERNAME`, `SSH_KEY`, `ENV_FILE`) | Settings > Secrets and variables > Actions |
+| Slack Webhook | 피드백 알림 수신 | `FEEDBACK_WEB_HOOK_URL` |
+| 가비아 도메인 | HTTPS용 도메인 | 갱신/명의 관리 필요 |

--- a/TEAM_SETUP.md
+++ b/TEAM_SETUP.md
@@ -41,7 +41,7 @@
 2. App Store Connect에서 **App Transfer**로 앱을 조직 계정에 연결
    - 번들 ID, 버전 기록, 리뷰 기록은 유지됨 / 인앱결제·일부 분석 데이터는 이전 안 됨
 3. 조직 계정 명의로 서명키 재발급:
-   - `secrets/AuthKey_9FR2S6G86R.p8 복사본` → 신규 발급 키로 교체
+   - `secrets/AuthKey_9FR2S6G86R.p8` → 신규 발급 키로 교체
    - `.env`의 `APPLE_TEAM_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY` 갱신
 
 ---
@@ -69,7 +69,7 @@
 
 이 폴더는 `.gitignore`에 등록되어 있어 git에는 없음. 안전한 채널(비밀번호 관리자 공유 등)로 전달 — 채팅/이메일 평문 전달 금지.
 
-- `AuthKey_9FR2S6G86R.p8 복사본` — Apple 서명키 (재발급 시 폐기 가능)
+- `AuthKey_9FR2S6G86R.p8` — Apple 서명키 (재발급 시 폐기 가능)
 - `client_secret_*.json` — Google OAuth secret (재발급 시 폐기 가능)
 - `univallinfo-api.pem` — DigitalOcean 서버 SSH 키 (신규 키 등록 시 폐기 가능)
 

--- a/TEAM_SETUP.md
+++ b/TEAM_SETUP.md
@@ -41,7 +41,7 @@
 2. App Store Connect에서 **App Transfer**로 앱을 조직 계정에 연결
    - 번들 ID, 버전 기록, 리뷰 기록은 유지됨 / 인앱결제·일부 분석 데이터는 이전 안 됨
 3. 조직 계정 명의로 서명키 재발급:
-   - `secrets/AuthKey_9FR2S6G86R.p8` → 신규 발급 키로 교체
+   - `secrets/AuthKey_<KEY_ID>.p8` → 신규 발급 키로 교체
    - `.env`의 `APPLE_TEAM_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY` 갱신
 
 ---
@@ -69,7 +69,7 @@
 
 이 폴더는 `.gitignore`에 등록되어 있어 git에는 없음. 안전한 채널(비밀번호 관리자 공유 등)로 전달 — 채팅/이메일 평문 전달 금지.
 
-- `AuthKey_9FR2S6G86R.p8` — Apple 서명키 (재발급 시 폐기 가능)
+- `AuthKey_<KEY_ID>.p8` — Apple 서명키 (재발급 시 폐기 가능)
 - `client_secret_*.json` — Google OAuth secret (재발급 시 폐기 가능)
 - `univallinfo-api.pem` — DigitalOcean 서버 SSH 키 (신규 키 등록 시 폐기 가능)
 

--- a/TEAM_SETUP.md
+++ b/TEAM_SETUP.md
@@ -1,0 +1,105 @@
+# 팀 공용 계정 및 인프라 설정 가이드
+
+> 목표: 프로젝트에 연결된 계정들을 팀 공용 체계로 정리하고, 새로 합류하는 팀원도 동일한 권한으로 개발/배포에 참여할 수 있게 한다.
+
+---
+
+## 0. 사전 준비
+
+- [ ] 팀원 이메일, GitHub 계정, Apple ID 등 확보
+- [ ] 팀/회사 명의 결제수단 준비
+- [ ] `secrets/` 폴더 전달 방법 결정 (아래 6번 참고, git에 없으므로 별도 채널 필요)
+
+---
+
+## 1. GitHub
+
+1. GitHub **Organization** 생성 (무료 플랜 가능)
+2. 기존 리포지토리를 Organization으로 **Transfer** (Settings > General > Danger Zone > Transfer ownership)
+3. 팀원을 Organization **Owner**로 초대
+4. Settings > Secrets and variables > Actions 에서 기존 시크릿 값 확인:
+   - `HOST`, `USERNAME`, `SSH_KEY`, `ENV_FILE`
+   - Organization 전환 시 자동으로 넘어가지 않을 수 있으니 재등록 필요 여부 확인
+
+---
+
+## 2. DigitalOcean
+
+1. DigitalOcean **Team** 생성 (또는 기존 계정을 Team으로 전환)
+2. 결제수단을 팀/회사 카드로 등록
+3. 팀원을 Team에 **Owner** 권한으로 초대
+4. 서버(droplet) 접근을 위한 SSH 키 등록:
+   - 팀원의 SSH 공개키를 서버 `~/.ssh/authorized_keys`에 추가
+   - GitHub Actions 시크릿의 `SSH_KEY`도 필요 시 갱신
+
+---
+
+## 3. Apple Developer
+
+1. **Apple Developer Program (Organization)** 계정 준비
+   - 사업자등록번호/D-U-N-S 번호 필요 (없으면 Apple이 무료 발급, 1~2주 소요될 수 있음)
+2. App Store Connect에서 **App Transfer**로 앱을 조직 계정에 연결
+   - 번들 ID, 버전 기록, 리뷰 기록은 유지됨 / 인앱결제·일부 분석 데이터는 이전 안 됨
+3. 조직 계정 명의로 서명키 재발급:
+   - `secrets/AuthKey_9FR2S6G86R.p8 복사본` → 신규 발급 키로 교체
+   - `.env`의 `APPLE_TEAM_ID`, `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY` 갱신
+
+---
+
+## 4. Google Play Console / Google Cloud
+
+1. 팀 공용 **Google Play Console** 계정 준비 (또는 Google Workspace 팀 계정)
+2. Play Console에서 앱에 팀원을 초대해 관리 권한 부여
+3. **Google Cloud Console**에서 OAuth Client(`GOOGLE_WEB_CLIENT_ID`)가 있는 프로젝트에 팀원을 IAM Owner로 추가
+   - 또는 팀 계정으로 OAuth Client 재발급 후 `.env`의 `GOOGLE_WEB_CLIENT_ID`, `GOOGLE_WEB_CLIENT_SECRET` 교체
+4. `secrets/client_secret_*.json` 파일도 재발급된 값으로 교체
+
+---
+
+## 5. 도메인 (가비아, HTTPS용)
+
+1. 가비아 마이페이지 > 나의 서비스 관리 > 도메인 관리 에서 대상 도메인 확인 (정확한 메뉴명은 UI 변경 가능성이 있어 로그인 후 재확인 권장)
+2. 결제수단(자동연장 등록 카드)을 팀 명의로 변경
+3. 필요 시 공동 관리자 계정 등록 또는 도메인 정보변경 신청 (본인확인/법인 서류 필요할 수 있어 가비아 고객센터 확인 권장)
+4. 갱신일을 캘린더에 등록해 만료 전 알림 받도록 조치 (1년 단위 구매분, 만료 시 HTTPS 인증서 발급이 막힘)
+
+---
+
+## 6. `secrets/` 폴더 및 로컬 자격증명
+
+이 폴더는 `.gitignore`에 등록되어 있어 git에는 없음. 안전한 채널(비밀번호 관리자 공유 등)로 전달 — 채팅/이메일 평문 전달 금지.
+
+- `AuthKey_9FR2S6G86R.p8 복사본` — Apple 서명키 (재발급 시 폐기 가능)
+- `client_secret_*.json` — Google OAuth secret (재발급 시 폐기 가능)
+- `univallinfo-api.pem` — DigitalOcean 서버 SSH 키 (신규 키 등록 시 폐기 가능)
+
+가능하면 기존 키를 재사용하기보다 **새로 발급하고 기존 키는 폐기**하는 편이 보안상 안전함.
+
+---
+
+## 7. Slack Webhook
+
+1. Slack Workspace 관리 권한을 팀 계정 기준으로 정리
+2. `FEEDBACK_WEB_HOOK_URL`이 개인 앱 설정에 묶여있다면 팀 계정 기준으로 Incoming Webhook 재발급
+
+---
+
+## 8. `.env` / `.env.prod` 최종 정리
+
+- [ ] 로컬 `.env`, 서버의 `.env.prod` 값을 갱신된 자격증명으로 전체 교체
+- [ ] GitHub Actions 시크릿 `ENV_FILE`도 동일하게 업데이트
+- [ ] 배포 1회 실행하여 정상 기동 확인 (`docker-compose -f docker-compose.prod.yml up -d`)
+
+---
+
+## 9. 최종 점검 체크리스트
+
+- [ ] GitHub Organization 전환 및 Owner 등록 완료
+- [ ] DigitalOcean Team 전환 및 SSH 키 등록 완료
+- [ ] Apple App Transfer 완료, 서명키 재발급 완료
+- [ ] Google Play / Cloud 팀 계정 연결 완료, OAuth secret 재발급 완료
+- [ ] 가비아 도메인 결제/관리 권한 정리 완료
+- [ ] `secrets/` 내 모든 키 재발급 완료
+- [ ] Slack Webhook 재발급 완료
+- [ ] `.env`, `.env.prod`, GitHub Actions `ENV_FILE` 전체 갱신 완료
+- [ ] 프로덕션 배포 1회 성공 확인

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - .:/usr/src/app
       - /usr/src/app/node_modules
     command: sh -c "npm run migration:run && exec npm run start:dev"
+    restart: on-failure
     env_file:
       - .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # 로컬 코드를 컨테이너에 동기화 (Hot Reload용)
       - .:/usr/src/app
       - /usr/src/app/node_modules
-    command: sh -c "npm run migration:run && npm run start:dev"
+    command: sh -c "npm run migration:run && exec npm run start:dev"
     env_file:
       - .env
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       # 로컬 코드를 컨테이너에 동기화 (Hot Reload용)
       - .:/usr/src/app
       - /usr/src/app/node_modules
-    command: npm run start:dev
+    command: sh -c "npm run migration:run && npm run start:dev"
     env_file:
       - .env
     environment:

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "migration:generate": "npm run typeorm:dev -- migration:generate -d src/config/typeorm.config.ts",
     "migration:run": "npm run typeorm:dev -- migration:run -d src/config/typeorm.config.ts",
     "typeorm:prod": "node ./node_modules/typeorm/cli.js",
-    "migration:run:prod": "npm run typeorm:prod -- migration:run -d dist/config/typeorm.config.js",
-    "api-docs": "node .github/scripts/generate-api-docs.js",
-    "api-docs:test": "node .github/scripts/test-local.js"
+    "migration:run:prod": "npm run typeorm:prod -- migration:run -d dist/config/typeorm.config.js"
   },
   "dependencies": {
     "@nestjs-modules/ioredis": "^2.2.1",
@@ -41,7 +39,6 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.1.1",
     "@nestjs/typeorm": "^11.0.1",
-    "@notionhq/client": "^2.3.0",
     "apple-signin-auth": "^2.0.0",
     "axios": "^1.15.0",
     "bcrypt": "^6.0.0",
@@ -55,7 +52,6 @@
     "ioredis": "^5.10.1",
     "modern-ahocorasick": "^2.0.4",
     "mysql2": "^3.20.0",
-    "openai": "^4.104.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",


### PR DESCRIPTION
## Summary

- 로컬 개발 환경을 `docker-compose up` 한 번으로 재현 가능하게 정리
- README를 실제 모듈 구조에 맞춰 갱신
- 미사용 의존성/환경변수 정리
- 팀 공용 계정 설정 가이드(`TEAM_SETUP.md`) 추가

Closes #51

## Key Changes

- `docker-compose.yml`: dev 서버 기동 전 마이그레이션 자동 실행
- `README.md`: (예정)으로 남아있던 모듈들을 실제 구현 상태로 갱신, 셋업 절차 단순화, 필수 자격증명 표 추가
- `.env.example`, `package.json`: Notion API 문서화 워크플로우 삭제 이후 남아있던 잔재(`OPENAI_API_KEY`, `NOTION_API_TOKEN`, `NOTION_DATABASE_ID`, `openai`, `@notionhq/client`, `api-docs` 스크립트) 정리
- `TEAM_SETUP.md`: GitHub, DigitalOcean, Apple Developer, Google Play/Cloud, 도메인, `secrets/` 자격증명, Slack 등 계정을 팀 공용 체계로 정리하기 위한 절차 문서

## Test plan

- [x] `docker-compose up -d` 실행 후 마이그레이션 및 서버 정상 기동 확인
- [x] README 안내대로 신규 클론 환경에서 셋업 재현 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)