### PR TITLE
fix: 전수조사 기반 컬럼 밀림 버그 수정 및 빈 게시판 정리 (#54)

### DIFF
--- a/src/scraper/rules/scraping-rules.json
+++ b/src/scraper/rules/scraping-rules.json
@@ -14,6 +14,13 @@
       {
         "name": "취업정보",
         "path": "/bbs/board.php?bo_table=sub6_3_b"
+      },
+      {
+        "name": "세미나및행사",
+        "path": "/bbs/board.php?bo_table=sub6_4",
+        "selectors": {
+          "date": "td:nth-child(4)"
+        }
       }
     ],
     "pageParam": "&page=",
@@ -23,24 +30,6 @@
       "isFixed": "img[alt=\"공지\"]",
       "title": "td:nth-child(2) a:not(.bo_cate_link)",
       "date": "td:nth-child(5)"
-    }
-  },
-  {
-    "code": "CSE",
-    "baseUrl": "https://cse.knu.ac.kr",
-    "boards": [
-      {
-        "name": "세미나및행사",
-        "path": "/bbs/board.php?bo_table=sub6_4"
-      }
-    ],
-    "pageParam": "&page=",
-    "maxPage": 1,
-    "selectors": {
-      "row": "table tbody tr:not(:first-child)",
-      "isFixed": "img[alt=\"공지\"]",
-      "title": "td:nth-child(2) a:not(.bo_cate_link)",
-      "date": "td:nth-child(4)"
     }
   },
   {
@@ -134,6 +123,13 @@
       {
         "name": "진로취업",
         "path": "/HOME/knujob/sub.htm?nav_code=knu1623817159"
+      },
+      {
+        "name": "현장실습",
+        "path": "/HOME/knujob/sub.htm?nav_code=knu1623826179",
+        "selectors": {
+          "date": "td:nth-child(5)"
+        }
       }
     ],
     "pageParam": "&page=",
@@ -143,24 +139,6 @@
       "isFixed": "img[alt=\"공지\"], .notice, .badge, .badge-notice, .notice_icon",
       "title": ".subject a",
       "date": "td:nth-child(6)"
-    }
-  },
-  {
-    "code": "CARE",
-    "baseUrl": "https://home.knu.ac.kr/",
-    "boards": [
-      {
-        "name": "현장실습",
-        "path": "/HOME/knujob/sub.htm?nav_code=knu1623826179"
-      }
-    ],
-    "pageParam": "&page=",
-    "maxPage": 1,
-    "selectors": {
-      "row": ".board_list tbody tr",
-      "isFixed": "img[alt=\"공지\"], .notice, .badge, .badge-notice, .notice_icon",
-      "title": ".subject a",
-      "date": "td:nth-child(5)"
     }
   },
   {
@@ -1016,6 +994,13 @@
       {
         "name": "자료실",
         "path": "/HOME/arch/sub.htm?nav_code=arc1623134220"
+      },
+      {
+        "name": "학년별공지사항",
+        "path": "/HOME/arch/sub.htm?nav_code=arc1623110358",
+        "selectors": {
+          "date": "td:nth-child(6)"
+        }
       }
     ],
     "pageParam": "&page=",
@@ -1025,24 +1010,6 @@
       "isFixed": "img[alt=\"공지\"], .notice, .badge, .badge-notice, .notice_icon",
       "title": ".subject a",
       "date": "td:nth-child(5)"
-    }
-  },
-  {
-    "code": "ARC",
-    "baseUrl": "https://home.knu.ac.kr",
-    "boards": [
-      {
-        "name": "학년별공지사항",
-        "path": "/HOME/arch/sub.htm?nav_code=arc1623110358"
-      }
-    ],
-    "pageParam": "&page=",
-    "maxPage": 1,
-    "selectors": {
-      "row": ".board_list tbody tr",
-      "isFixed": "img[alt=\"공지\"], .notice, .badge, .badge-notice, .notice_icon",
-      "title": ".subject a",
-      "date": "td:nth-child(6)"
     }
   },
   {

--- a/src/scraper/rules/scraping-rules.json
+++ b/src/scraper/rules/scraping-rules.json
@@ -5,19 +5,15 @@
     "boards": [
       {
         "name": "공지사항",
-        "path": "/bbs/board.php?bo_table=sub5_1"
+        "path": "/bbs/board.php?bo_table=sub6_1_a"
       },
       {
         "name": "학부인재모집",
-        "path": "/bbs/board.php?bo_table=sub5_3_a"
+        "path": "/bbs/board.php?bo_table=sub6_3_a"
       },
       {
         "name": "취업정보",
-        "path": "/bbs/board.php?bo_table=sub5_3_b"
-      },
-      {
-        "name": "세미나및행사",
-        "path": "/bbs/board.php?bo_table=sub5_4"
+        "path": "/bbs/board.php?bo_table=sub6_3_b"
       }
     ],
     "pageParam": "&page=",
@@ -27,6 +23,24 @@
       "isFixed": "img[alt=\"공지\"]",
       "title": "td:nth-child(2) a:not(.bo_cate_link)",
       "date": "td:nth-child(5)"
+    }
+  },
+  {
+    "code": "CSE",
+    "baseUrl": "https://cse.knu.ac.kr",
+    "boards": [
+      {
+        "name": "세미나및행사",
+        "path": "/bbs/board.php?bo_table=sub6_4"
+      }
+    ],
+    "pageParam": "&page=",
+    "maxPage": 1,
+    "selectors": {
+      "row": "table tbody tr:not(:first-child)",
+      "isFixed": "img[alt=\"공지\"]",
+      "title": "td:nth-child(2) a:not(.bo_cate_link)",
+      "date": "td:nth-child(4)"
     }
   },
   {
@@ -384,10 +398,6 @@
       {
         "name": "전시회소식",
         "path": "/HOME/vcd/sub.htm?nav_code=vcd1622551690"
-      },
-      {
-        "name": "구인구직",
-        "path": "/HOME/vcd/sub.htm?nav_code=vcd1622551702"
       }
     ],
     "pageParam": "&page=",
@@ -1004,10 +1014,6 @@
         "path": "/HOME/arch/sub.htm?nav_code=arc1623133855"
       },
       {
-        "name": "학년별공지사항",
-        "path": "/HOME/arch/sub.htm?nav_code=arc1623110358"
-      },
-      {
         "name": "자료실",
         "path": "/HOME/arch/sub.htm?nav_code=arc1623134220"
       }
@@ -1022,6 +1028,24 @@
     }
   },
   {
+    "code": "ARC",
+    "baseUrl": "https://home.knu.ac.kr",
+    "boards": [
+      {
+        "name": "학년별공지사항",
+        "path": "/HOME/arch/sub.htm?nav_code=arc1623110358"
+      }
+    ],
+    "pageParam": "&page=",
+    "maxPage": 1,
+    "selectors": {
+      "row": ".board_list tbody tr",
+      "isFixed": "img[alt=\"공지\"], .notice, .badge, .badge-notice, .notice_icon",
+      "title": ".subject a",
+      "date": "td:nth-child(6)"
+    }
+  },
+  {
     "code": "CHE",
     "baseUrl": "https://home.knu.ac.kr",
     "boards": [
@@ -1032,10 +1056,6 @@
       {
         "name": "채용",
         "path": "/HOME/cheme/sub.htm?nav_code=che1648009521"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/cheme/sub.htm?nav_code=che1646700318"
       }
     ],
     "pageParam": "&page=",
@@ -1274,10 +1294,6 @@
       {
         "name": "자료실",
         "path": "/HOME/acen/sub.htm?nav_code=ace1622521461"
-      },
-      {
-        "name": "행사안내",
-        "path": "/HOME/acen/sub.htm?nav_code=ace1622521460"
       }
     ],
     "pageParam": "&page=",
@@ -1324,10 +1340,6 @@
         "path": "/HOME/biofiber/sub.htm?nav_code=bio1623029353"
       },
       {
-        "name": "자료실",
-        "path": "/HOME/biofiber/sub.htm?nav_code=bio1623029352"
-      },
-      {
         "name": "취업정보",
         "path": "/HOME/biofiber/sub.htm?nav_code=bio1653980887"
       }
@@ -1370,10 +1382,6 @@
       {
         "name": "공지사항",
         "path": "/HOME/plantmed/sub.htm?nav_code=pla1677024917"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/plantmed/sub.htm?nav_code=pla1677024916"
       }
     ],
     "pageParam": "&page=",
@@ -1418,10 +1426,6 @@
       {
         "name": "자료실",
         "path": "/HOME/koredu/sub.htm?nav_code=kor1622459694"
-      },
-      {
-        "name": "행사 및 세미나",
-        "path": "/HOME/koredu/sub.htm?nav_code=kor1622459693"
       }
     ],
     "pageParam": "&page=",
@@ -1614,10 +1618,6 @@
       {
         "name": "자료실",
         "path": "/HOME/bioedu/sub.htm?nav_code=bio1622460187"
-      },
-      {
-        "name": "행사 및 세미나",
-        "path": "/HOME/bioedu/sub.htm?nav_code=bio1622460186"
       }
     ],
     "pageParam": "&page=",
@@ -1666,10 +1666,6 @@
       {
         "name": "자료실",
         "path": "/HOME/homeedu/sub.htm?nav_code=hom1622521249"
-      },
-      {
-        "name": "취업정보",
-        "path": "/HOME/homeedu/sub.htm?nav_code=hom1622521247"
       }
     ],
     "pageParam": "&page=",
@@ -1714,10 +1710,6 @@
       {
         "name": "공지사항",
         "path": "/HOME/comedu/sub.htm?nav_code=com1744781375"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/comedu/sub.htm?nav_code=com1744781474"
       }
     ],
     "pageParam": "&page=",
@@ -1784,10 +1776,6 @@
       {
         "name": "공지사항",
         "path": "/HOME/veterinary/sub.htm?nav_code=vet1623200224"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/veterinary/sub.htm?nav_code=vet1623236651"
       }
     ],
     "pageParam": "&page=",
@@ -2168,10 +2156,6 @@
       {
         "name": "공지사항",
         "path": "/HOME/appbio/sub.htm?nav_code=app1700444270"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/appbio/sub.htm?nav_code=app1700444283"
       }
     ],
     "pageParam": "&page=",
@@ -2212,10 +2196,6 @@
       {
         "name": "공지사항",
         "path": "/HOME/forest/sub.htm?nav_code=for1622521051"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/forest/sub.htm?nav_code=for1622521050"
       },
       {
         "name": "행사안내",
@@ -2260,10 +2240,6 @@
       {
         "name": "공지사항",
         "path": "/HOME/land/sub.htm?nav_code=lan1614079746"
-      },
-      {
-        "name": "자료실",
-        "path": "/HOME/land/sub.htm?nav_code=lan1616034015"
       },
       {
         "name": "행사안내",

--- a/src/scraper/scraper.interface.ts
+++ b/src/scraper/scraper.interface.ts
@@ -1,18 +1,27 @@
+export interface ScrapeSelectors {
+  row: string; // 반복되는 각 공지글 묶음 (예: 'tbody tr' 또는 'ul > li')
+  isFixed: string; // 공지/상단고정글 판단 기준 (예: '.notice_icon')
+  title: string; // 링크(href) 추출용 앵커 엘리먼트 (예: 'td.subject a' 또는 '.title-text')
+  date: string; // 날짜 엘리먼트 (예: 'td.date')
+  // title 엘리먼트 안에 뱃지/본문 미리보기가 섞여 있어 텍스트만 별도로 뽑아야 하는 경우 사용
+  titleText?: string; // 제목 텍스트 전용 엘리먼트 (미지정 시 title 엘리먼트 텍스트 사용)
+  titleTextExclude?: string; // titleText 안에서 제외할 하위 엘리먼트 (예: 뱃지 span)
+}
+
 export interface ScrapeConfig {
   code: string; // 예: 'CSE'
   baseUrl: string; // 기본 주소
-  boards: { name: string; path: string; maxItems?: number }[]; // 게시판들 (maxItems: 페이지네이션 없이 전체 글이 한 번에 나오는 게시판에서 상위 N건만 수집)
+  boards: {
+    name: string;
+    path: string;
+    maxItems?: number; // 페이지네이션 없이 전체 글이 한 번에 나오는 게시판에서 상위 N건만 수집
+    // 같은 사이트라도 게시판마다 컬럼 구조(특히 날짜 위치)가 다른 경우,
+    // config.selectors 중 일부만 이 게시판에서 덮어쓸 때 사용
+    selectors?: Partial<ScrapeSelectors>;
+  }[];
   pageParam: string | null; // 페이징 파라미터 (예: '?page=')
   maxPage: number; // 긁어올 최대 페이지 수
 
-  // HTML 구조 종속성 탈피를 위한 CSS Selector 지정
-  selectors: {
-    row: string; // 반복되는 각 공지글 묶음 (예: 'tbody tr' 또는 'ul > li')
-    isFixed: string; // 공지/상단고정글 판단 기준 (예: '.notice_icon')
-    title: string; // 링크(href) 추출용 앵커 엘리먼트 (예: 'td.subject a' 또는 '.title-text')
-    date: string; // 날짜 엘리먼트 (예: 'td.date')
-    // title 엘리먼트 안에 뱃지/본문 미리보기가 섞여 있어 텍스트만 별도로 뽑아야 하는 경우 사용
-    titleText?: string; // 제목 텍스트 전용 엘리먼트 (미지정 시 title 엘리먼트 텍스트 사용)
-    titleTextExclude?: string; // titleText 안에서 제외할 하위 엘리먼트 (예: 뱃지 span)
-  };
+  // HTML 구조 종속성 탈피를 위한 CSS Selector 지정 (게시판 기본값)
+  selectors: ScrapeSelectors;
 }

--- a/src/scraper/utils/extractor.util.ts
+++ b/src/scraper/utils/extractor.util.ts
@@ -11,6 +11,8 @@ export const extractNotices = async (
   board: ScrapeConfig['boards'][number],
 ): Promise<Partial<Notice>[]> => {
   const notices: Partial<Notice>[] = [];
+  // 게시판별 selectors override가 있으면 config 기본값 위에 덮어씀
+  const selectors = { ...config.selectors, ...board.selectors };
 
   for (let page = 1; page <= config.maxPage; page++) {
     const targetUrl = config.pageParam
@@ -32,7 +34,7 @@ export const extractNotices = async (
       });
       const $ = cheerio.load(response.data as string);
 
-      $(config.selectors.row).each((_, element) => {
+      $(selectors.row).each((_, element) => {
         // 페이지네이션 없이 전체 글이 한 번에 나오는 게시판은 maxItems로 상위 N건만 수집
         if (
           board.maxItems &&
@@ -42,15 +44,15 @@ export const extractNotices = async (
           return false;
         }
 
-        const titleEl = $(element).find(config.selectors.title);
+        const titleEl = $(element).find(selectors.title);
 
         // 제목 엘리먼트 안에 뱃지/본문 미리보기 등이 섞여 있는 사이트는
         // titleText(+titleTextExclude)로 텍스트만 별도로 뽑아냄
-        const titleTextEl = config.selectors.titleText
-          ? $(element).find(config.selectors.titleText).clone()
+        const titleTextEl = selectors.titleText
+          ? $(element).find(selectors.titleText).clone()
           : titleEl.clone();
-        if (config.selectors.titleTextExclude) {
-          titleTextEl.find(config.selectors.titleTextExclude).remove();
+        if (selectors.titleTextExclude) {
+          titleTextEl.find(selectors.titleTextExclude).remove();
         }
         // 제목의 보기 흉한 줄바꿈과 다중 스페이스를 하나의 공백으로 압축합니다 (깔끔한 UI 제공)
         const title = titleTextEl
@@ -98,15 +100,12 @@ export const extractNotices = async (
           rawLink = rawLink.replace(/\/>/g, '');
         }
 
-        const postedAtString = $(element)
-          .find(config.selectors.date)
-          .text()
-          .trim();
+        const postedAtString = $(element).find(selectors.date).text().trim();
 
         if (!title || !rawLink) return;
 
         // 고정 공지 여부 파악 로직 추가 가능
-        // const isFixed = $(element).find(config.selectors.isFixed).length > 0;
+        // const isFixed = $(element).find(selectors.isFixed).length > 0;
 
         // 상대 경로 보정 (현재 탐색 중인 게시판 주소 기준)
         let fullUrl = '';


### PR DESCRIPTION
269개 게시판 전체를 실제 extractNotices 로직으로 재현 검증

- CSE(컴퓨터학부): 사이트 리뉴얼로 bo_table 코드가 죽어있던 4개 게시판 URL 전부 최신 코드로 갱신 (공지사항/학부인재모집/ 취업정보/세미나및행사)
- CSE 세미나및행사: 다른 게시판과 달리 작성자 컬럼이 없는 4컬럼 구조라 date selector 밀림 — 별도 config로 분리해 수정 (ARC 학년별공지사항과 동일 패턴)
- 실제로 게시물이 없는(등록된 내용이 없습니다) 빈 게시판 13개 제거: VCD 구인구직, CHE/BFS/PMD/ICED/VET/ABS/FOR/LAR 자료실, AGM 행사안내, KED/BIED 행사및세미나, HMED 취업정보

재검증 결과 남은 이슈는 PSY 자유게시판 1건뿐 — 이 게시판은 구조상
작성일 컬럼 자체가 없어 기존 안전장치(오늘 날짜 대체)가 정상
작동하는 것으로, 데이터 오염 위험 없음